### PR TITLE
remove unnecessary transform tables

### DIFF
--- a/ecoInvent.py
+++ b/ecoInvent.py
@@ -10,14 +10,10 @@ generate_table('consequential_ao_raw')
 generate_table('products_activities_transformed')
 
 generate_table('lcia_methods_raw')
-generate_table('lcia_methods_transform')
 
 generate_table('impact_categories_raw')
-generate_table('impact_categories_transform')
 
 generate_table('intermediate_exchanges_raw')
-generate_table('intermediate_exchanges_transform')
 
 generate_table('elementary_exchanges_raw')
-generate_table('elementary_exchanges_transform')
 

--- a/functions/processing.py
+++ b/functions/processing.py
@@ -121,23 +121,11 @@ def generate_table(table_name: str) -> None:
 
         write_table(spark_generate, df, 'lcia_methods_raw')
 
-    elif table_name == 'lcia_methods_transform':
-
-        df = read_table(spark_generate, 'lcia_methods_raw')
-
-        write_table(spark_generate, df, 'lcia_methods_transform')
-
     elif table_name == 'impact_categories_raw':
 
         df = read_table(spark_generate, 'impact_categories_landingzone')
 
         write_table(spark_generate, df, 'impact_categories_raw')
-
-    elif table_name == 'impact_categories_transform':
-
-        df = read_table(spark_generate, 'impact_categories_raw')
-
-        write_table(spark_generate, df, 'impact_categories_transform')
 
     elif table_name == 'intermediate_exchanges_raw':
 
@@ -145,23 +133,11 @@ def generate_table(table_name: str) -> None:
 
         write_table(spark_generate, df, 'intermediate_exchanges_raw')
 
-    elif table_name == 'intermediate_exchanges_transform':
-
-        df = read_table(spark_generate, 'intermediate_exchanges_raw')
-
-        write_table(spark_generate, df, 'intermediate_exchanges_transform')
-
     elif table_name == 'elementary_exchanges_raw':
 
         df = read_table(spark_generate, 'elementary_exchanges_landingzone')
 
         write_table(spark_generate, df, 'elementary_exchanges_raw')
-
-    elif table_name == 'elementary_exchanges_transform':
-
-        df = read_table(spark_generate, 'elementary_exchanges_raw')
-
-        write_table(spark_generate, df, 'elementary_exchanges_transform')
 
     elif table_name == 'issues_companies_raw':
 

--- a/functions/spark_session.py
+++ b/functions/spark_session.py
@@ -108,9 +108,16 @@ def write_table(spark_session: SparkSession, data_frame: DataFrame, table_name: 
     if table_check:
         table_location = build_table_path(table_definition['container'], table_definition['location'], None)
         if partition:
-            data_frame.write.partitionBy(partition).mode('overwrite').parquet(table_location)
+            if table_definition['type'] == 'csv':
+                data_frame.write.partitionBy(partition).mode('overwrite').csv(table_location)
+            else:
+                data_frame.write.partitionBy(partition).mode('overwrite').parquet(table_location)
+            
         else:
-            data_frame.coalesce(1).write.mode('overwrite').parquet(table_location)
+            if table_definition['type'] == 'csv':
+                data_frame.coalesce(1).write.mode('overwrite').csv(table_location)
+            else:
+                data_frame.coalesce(1).write.mode('overwrite').parquet(table_location)
     else:
         raise ValueError("Table format validation failed.")
 

--- a/functions/tables.py
+++ b/functions/tables.py
@@ -64,7 +64,7 @@ def get_table_definition(table_name: str) -> dict:
             'partition_by' : '',
             'quality_checks': []
         },
-        'unindentified_ao_landingzone': {
+        'undefined_ao_landingzone': {
             'columns' :  StructType([
                 StructField('Activity UUID', StringType(), True),
                 StructField('EcoQuery URL', StringType(), True),


### PR DESCRIPTION
I removed all of the tables from the transform layer that do not undergo any transformations between the raw and the transformed layer. The two tables that undergo transformations are the geographies table and the ao tables. The geographies table is split out into the geographies table and all of the related geographies. The AO tables are summarized into the product and activities including a mapping between those under different AO codes. 