### PR TITLE
Adjusted decimal values and delimiter for csv

### DIFF
--- a/functions/processing.py
+++ b/functions/processing.py
@@ -1,7 +1,7 @@
 from functions.spark_session import read_table, write_table, create_spark_session
 import pyspark.sql.functions as F
 from pyspark.sql.functions import col, when
-from pyspark.sql.types import FloatType, IntegerType, TimestampType, BooleanType, DecimalType, ShortType
+from pyspark.sql.types import FloatType, IntegerType, TimestampType, BooleanType, DecimalType, ShortType, FloatType
 
 
 def generate_table(table_name: str) -> None:
@@ -333,7 +333,7 @@ def generate_table(table_name: str) -> None:
 
         # to decimal values
         column_name = "logprob"
-        ep_ei_matcher = ep_ei_matcher.withColumn(column_name, col(column_name).cast(DecimalType(38,18)))  
+        ep_ei_matcher = ep_ei_matcher.withColumn(column_name, col(column_name).cast(FloatType()))  
 
         write_table(spark_generate, ep_ei_matcher, 'ep_ei_matcher_raw')  
 
@@ -350,7 +350,7 @@ def generate_table(table_name: str) -> None:
         column_names = ["Value", "Reductions"]
         # to decimal values
         for column in column_names:
-            scenario_targets_IPR_NEW = scenario_targets_IPR_NEW.withColumn(column, col(column).cast(DecimalType(38,2))) 
+            scenario_targets_IPR_NEW = scenario_targets_IPR_NEW.withColumn(column, col(column).cast(FloatType())) 
 
         write_table(spark_generate, scenario_targets_IPR_NEW, 'scenario_targets_IPR_NEW_raw') 
 
@@ -367,7 +367,7 @@ def generate_table(table_name: str) -> None:
         column_names = ["VALUE", "REDUCTIONS"]
         # to decimal values
         for column in column_names:
-            scenario_targets_WEO_NEW = scenario_targets_WEO_NEW.withColumn(column, col(column).cast(DecimalType(38,2)))  
+            scenario_targets_WEO_NEW = scenario_targets_WEO_NEW.withColumn(column, col(column).cast(FloatType()))  
 
         write_table(spark_generate, scenario_targets_WEO_NEW, 'scenario_targets_WEO_NEW_raw') 
 
@@ -408,7 +408,7 @@ def generate_table(table_name: str) -> None:
 
         # to replace to decimal values
         column_name = "ipcc_2021_climate_change_global_warming_potential_gwp100_kg_co2_eq"
-        ecoinvent_licenced = ecoinvent_licenced.withColumn(column_name, col(column_name).cast(DecimalType(38,10)))
+        ecoinvent_licenced = ecoinvent_licenced.withColumn(column_name, col(column_name).cast(FloatType()))
 
         write_table(spark_generate, ecoinvent_licenced, 'ecoinvent-v3.9.1_raw') 
 
@@ -426,7 +426,7 @@ def generate_table(table_name: str) -> None:
 
         # to replace to decimal values
         column_name = "exchange amount"
-        ecoinvent_input_data_relevant_columns_raw = ecoinvent_input_data_relevant_columns_raw.withColumn(column_name, col(column_name).cast(DecimalType(38,18)))
+        ecoinvent_input_data_relevant_columns_raw = ecoinvent_input_data_relevant_columns_raw.withColumn(column_name, col(column_name).cast(FloatType()))
 
         write_table(spark_generate, ecoinvent_input_data_relevant_columns_raw, 'ecoinvent_input_data_relevant_columns_raw') 
 

--- a/functions/processing.py
+++ b/functions/processing.py
@@ -333,7 +333,7 @@ def generate_table(table_name: str) -> None:
 
         # to decimal values
         column_name = "logprob"
-        ep_ei_matcher = ep_ei_matcher.withColumn(column_name, col(column_name).cast(DecimalType()))  
+        ep_ei_matcher = ep_ei_matcher.withColumn(column_name, col(column_name).cast(DecimalType(38,18)))  
 
         write_table(spark_generate, ep_ei_matcher, 'ep_ei_matcher_raw')  
 
@@ -350,7 +350,7 @@ def generate_table(table_name: str) -> None:
         column_names = ["Value", "Reductions"]
         # to decimal values
         for column in column_names:
-            scenario_targets_IPR_NEW = scenario_targets_IPR_NEW.withColumn(column, col(column).cast(DecimalType())) 
+            scenario_targets_IPR_NEW = scenario_targets_IPR_NEW.withColumn(column, col(column).cast(DecimalType(38,2))) 
 
         write_table(spark_generate, scenario_targets_IPR_NEW, 'scenario_targets_IPR_NEW_raw') 
 
@@ -367,7 +367,7 @@ def generate_table(table_name: str) -> None:
         column_names = ["VALUE", "REDUCTIONS"]
         # to decimal values
         for column in column_names:
-            scenario_targets_WEO_NEW = scenario_targets_WEO_NEW.withColumn(column, col(column).cast(DecimalType()))  
+            scenario_targets_WEO_NEW = scenario_targets_WEO_NEW.withColumn(column, col(column).cast(DecimalType(38,2)))  
 
         write_table(spark_generate, scenario_targets_WEO_NEW, 'scenario_targets_WEO_NEW_raw') 
 
@@ -408,7 +408,7 @@ def generate_table(table_name: str) -> None:
 
         # to replace to decimal values
         column_name = "ipcc_2021_climate_change_global_warming_potential_gwp100_kg_co2_eq"
-        ecoinvent_licenced = ecoinvent_licenced.withColumn(column_name, col(column_name).cast(DecimalType()))
+        ecoinvent_licenced = ecoinvent_licenced.withColumn(column_name, col(column_name).cast(DecimalType(38,10)))
 
         write_table(spark_generate, ecoinvent_licenced, 'ecoinvent-v3.9.1_raw') 
 
@@ -426,7 +426,7 @@ def generate_table(table_name: str) -> None:
 
         # to replace to decimal values
         column_name = "exchange amount"
-        ecoinvent_input_data_relevant_columns_raw = ecoinvent_input_data_relevant_columns_raw.withColumn(column_name, col(column_name).cast(DecimalType()))
+        ecoinvent_input_data_relevant_columns_raw = ecoinvent_input_data_relevant_columns_raw.withColumn(column_name, col(column_name).cast(DecimalType(38,18)))
 
         write_table(spark_generate, ecoinvent_input_data_relevant_columns_raw, 'ecoinvent_input_data_relevant_columns_raw') 
 

--- a/functions/spark_session.py
+++ b/functions/spark_session.py
@@ -71,10 +71,32 @@ def read_table(read_session: SparkSession, table_name: str, partition: str = '')
 
     table_location = build_table_path(table_definition['container'], table_definition['location'], partition_path)
 
+    
     if table_definition['type'] == 'csv':
         df = read_session.read.format(table_definition['type']).schema(table_definition['columns']).option('header', True).option("quote", '"').option("multiline", 'True').load(table_location)
     else:
         df = read_session.read.format(table_definition['type']).schema(table_definition['columns']).option('header', True).load(table_location)
+
+    # first_line = read_session.read.load(table_location).readline()
+    # # Determine the delimiter based on the content of the first line
+    # if ";" in first_line:
+    #     delimiter = ";"
+    # else:
+    #     delimiter = ","
+    # #     # Configure read options
+    # read_options = {
+    #     "header": True,          # Assumes first row is the header
+    #     "inferSchema": True,    # Handle flexible content
+    #     "delimiter": delimiter,  # Specify the delimiter
+    #     "escape": "\\",          # Specify the escape character
+    #     "quote": '"',            # Specify the quote character
+    #     "multiline": True        # Allow multiline cells
+    #     }
+
+    # if table_definition['type'] == 'csv':
+    #     df = read_session.read.format(table_definition['type']).schema(table_definition['columns']).options(**read_options).load(table_location)
+    # else:
+    #     df = read_session.read.format(table_definition['type']).schema(table_definition['columns']).option('header', True).load(table_location)
 
 
     if partition != '':
@@ -121,6 +143,9 @@ def write_table(spark_session: SparkSession, data_frame: DataFrame, table_name: 
                 data_frame.coalesce(1).write.mode('overwrite').csv(table_location)
             else:
                 data_frame.coalesce(1).write.mode('overwrite').parquet(table_location)
+
+
+    
     else:
         raise ValueError("Table format validation failed.")
 

--- a/functions/spark_session.py
+++ b/functions/spark_session.py
@@ -136,9 +136,6 @@ def write_table(spark_session: SparkSession, data_frame: DataFrame, table_name: 
                 data_frame.coalesce(1).write.mode('overwrite').csv(table_location)
             else:
                 data_frame.coalesce(1).write.mode('overwrite').parquet(table_location)
-
-
-    
     else:
         raise ValueError("Table format validation failed.")
 

--- a/functions/spark_session.py
+++ b/functions/spark_session.py
@@ -71,33 +71,10 @@ def read_table(read_session: SparkSession, table_name: str, partition: str = '')
 
     table_location = build_table_path(table_definition['container'], table_definition['location'], partition_path)
 
-    
     if table_definition['type'] == 'csv':
         df = read_session.read.format(table_definition['type']).schema(table_definition['columns']).option('header', True).option("quote", '"').option("multiline", 'True').load(table_location)
     else:
         df = read_session.read.format(table_definition['type']).schema(table_definition['columns']).option('header', True).load(table_location)
-
-    # first_line = read_session.read.load(table_location).readline()
-    # # Determine the delimiter based on the content of the first line
-    # if ";" in first_line:
-    #     delimiter = ";"
-    # else:
-    #     delimiter = ","
-    # #     # Configure read options
-    # read_options = {
-    #     "header": True,          # Assumes first row is the header
-    #     "inferSchema": True,    # Handle flexible content
-    #     "delimiter": delimiter,  # Specify the delimiter
-    #     "escape": "\\",          # Specify the escape character
-    #     "quote": '"',            # Specify the quote character
-    #     "multiline": True        # Allow multiline cells
-    #     }
-
-    # if table_definition['type'] == 'csv':
-    #     df = read_session.read.format(table_definition['type']).schema(table_definition['columns']).options(**read_options).load(table_location)
-    # else:
-    #     df = read_session.read.format(table_definition['type']).schema(table_definition['columns']).option('header', True).load(table_location)
-
 
     if partition != '':
         df = df.withColumn(table_partition, F.lit(partition))
@@ -166,7 +143,6 @@ def build_table_path(container: str, location: str, partition: str) -> str:
         None
 
     """
-
     if partition:
         # Return the table path with the specified partition
         return f'abfss://{container}@storagetilt{env}.dfs.core.windows.net/{location}/{partition}'

--- a/functions/tables.py
+++ b/functions/tables.py
@@ -1282,7 +1282,7 @@ def get_table_definition(table_name: str) -> dict:
                 StructField('activity_uuid_product_uuid', StringType(), True),
                 StructField('multi_match', BooleanType(), True),
                 StructField('completion', StringType(), True),
-                StructField('logprob', DecimalType(), True),
+                StructField('logprob', FloatType(), True),
                 StructField('category', StringType(), True),
                 StructField('bert_activities', StringType(), True),
                 StructField('bert_epact_lcaprod', StringType(), True),
@@ -1325,8 +1325,8 @@ def get_table_definition(table_name: str) -> dict:
                 StructField('Sub Sector', StringType(), True),
                 StructField('Units', StringType(), True),
                 StructField('Year', ShortType(), True),
-                StructField('Value', DecimalType(), True),
-                StructField('Reductions', DecimalType(), True),
+                StructField('Value', FloatType(), True),
+                StructField('Reductions', FloatType(), True),
                 StructField('tiltRecordID', StringType(), False)
             ]  
             ), 
@@ -1366,8 +1366,8 @@ def get_table_definition(table_name: str) -> dict:
                 StructField('UNIT', StringType(), True),
                 StructField('REGION', StringType(), True),
                 StructField('YEAR', ShortType(), True),
-                StructField('VALUE', DecimalType(), True),
-                StructField('REDUCTIONS', DecimalType(), True),
+                StructField('VALUE', FloatType(), True),
+                StructField('REDUCTIONS', FloatType(), True),
                 StructField('tiltRecordID', StringType(), False)
             ]  
             ), 
@@ -1509,7 +1509,7 @@ def get_table_definition(table_name: str) -> dict:
                 StructField('unit', StringType(), True),
                 StructField('method_category_indicator_product_information', StringType(), True),
                 StructField('product_inputs_tbc', StringType(), True),
-                StructField('ipcc_2021_climate_change_global_warming_potential_gwp100_kg_co2_eq', DecimalType(), True),
+                StructField('ipcc_2021_climate_change_global_warming_potential_gwp100_kg_co2_eq', FloatType(), True),
                 StructField('tiltRecordID', StringType(), False)
             ]  
             ), 
@@ -1593,7 +1593,7 @@ def get_table_definition(table_name: str) -> dict:
                 StructField('activityLink_activityName', StringType(), True),
                 StructField('activityLink_geography', StringType(), True),
                 StructField('exchange unitName', StringType(), True),
-                StructField('exchange amount', DecimalType(), True),
+                StructField('exchange amount', FloatType(), True),
                 StructField('CPC_classificationValue', StringType(), True),
                 StructField('By-product classification_classificationValue', StringType(), True),
                 StructField('tiltRecordID', StringType(), False)

--- a/functions/tables.py
+++ b/functions/tables.py
@@ -1600,7 +1600,7 @@ def get_table_definition(table_name: str) -> dict:
             ]  
             ), 
             'container': 'raw',
-            'location': 'ecoinvent_input_data_relevant_columns_raw',
+            'location': 'ecoinvent_input_data_relevant_columns',
             'type': 'parquet',
             'partition_by' : '',
             'quality_checks': []


### PR DESCRIPTION
I have adjusted a few things based on the feedback from Kalash. Main things to keep in mind for now:

- DecimalType (precision and scale need to be specified for all values). I adjusted it for all input data for the package
- Delimiter separator when reading csv files. Usually the separator is comma and that is the default option, however I noticed one table 'ecoinvent_input_overview_raw' seem to have semicolon separator. I've tried to adjust the function to read both options, but it then works for either but not both at the same time. The files are in correct format now, but we either need to fix the function to allow for both options or make sure that only the csv files with comma separator are loaded to the data storage.