### PR TITLE
47 implement unique format for ecoinvent due to formatting issues

### DIFF
--- a/functions/spark_session.py
+++ b/functions/spark_session.py
@@ -74,7 +74,9 @@ def read_table(read_session: SparkSession, table_name: str, partition: str = '')
 
     try:
         if table_definition['type'] == 'csv':
-            df = read_session.read.format(table_definition['type']).schema(table_definition['columns']).option('header', True).option("quote", '"').option("multiline", 'True').load(table_location)
+            df = read_session.read.format('csv').schema(table_definition['columns']).option('header', True).option("quote", '"').option("multiline", 'True').load(table_location)
+        if table_definition['type'] == 'ecoInvent':
+            df = read_session.read.format('csv').schema(table_definition['columns']).option('header', True).option("quote", '~').option('delimiter',';').option("multiline", 'True').load(table_location)
         else:
             df = read_session.read.format(table_definition['type']).schema(table_definition['columns']).option('header', True).load(table_location)
         # Force to load first record of the data to check if it throws an error

--- a/functions/tables.py
+++ b/functions/tables.py
@@ -18,7 +18,7 @@ def get_table_definition(table_name: str) -> dict:
             ), 
             'container': 'landingzone',
             'location': 'ecoInvent/Geographies.csv',
-            'type': 'csv',
+            'type': 'ecoInvent',
             'partition_by' : '',
             'quality_checks': []
         },
@@ -95,7 +95,7 @@ def get_table_definition(table_name: str) -> dict:
             ), 
             'container': 'landingzone',
             'location': 'ecoInvent/Undefined AO.csv',
-            'type': 'csv',
+            'type': 'ecoInvent',
             'partition_by' : '',
             'quality_checks': []
         },
@@ -151,7 +151,7 @@ def get_table_definition(table_name: str) -> dict:
             ), 
             'container': 'landingzone',
             'location': 'ecoInvent/Cut-OFF AO.csv',
-            'type': 'csv',
+            'type': 'ecoInvent',
             'partition_by' : '',
             'quality_checks': []
         },
@@ -208,7 +208,7 @@ def get_table_definition(table_name: str) -> dict:
             ), 
             'container': 'landingzone',
             'location': 'ecoInvent/EN15804 AO.csv',
-            'type': 'csv',
+            'type': 'ecoInvent',
             'partition_by' : '',
             'quality_checks': []
         },
@@ -265,7 +265,7 @@ def get_table_definition(table_name: str) -> dict:
             ), 
             'container': 'landingzone',
             'location': 'ecoInvent/Consequential AO.csv',
-            'type': 'csv',
+            'type': 'ecoInvent',
             'partition_by' : '',
             'quality_checks': []
         },
@@ -369,7 +369,7 @@ def get_table_definition(table_name: str) -> dict:
             ), 
             'container': 'landingzone',
             'location': 'ecoInvent/LCIA Methods.csv',
-            'type': 'csv',
+            'type': 'ecoInvent',
             'partition_by' : '',
             'quality_checks': []
         },
@@ -409,7 +409,7 @@ def get_table_definition(table_name: str) -> dict:
             ), 
             'container': 'landingzone',
             'location': 'ecoInvent/Impact Categories.csv',
-            'type': 'csv',
+            'type': 'ecoInvent',
             'partition_by' : '',
             'quality_checks': []
         },
@@ -453,7 +453,7 @@ def get_table_definition(table_name: str) -> dict:
             ), 
             'container': 'landingzone',
             'location': 'ecoInvent/Intermediate Exchanges.csv',
-            'type': 'csv',
+            'type': 'ecoInvent',
             'partition_by' : '',
             'quality_checks': []
         },
@@ -494,7 +494,7 @@ def get_table_definition(table_name: str) -> dict:
             ), 
             'container': 'landingzone',
             'location': 'ecoInvent/Elementary Exchanges.csv',
-            'type': 'csv',
+            'type': 'ecoInvent',
             'partition_by' : '',
             'quality_checks': []
         },


### PR DESCRIPTION
As discussed, this implements the ecoinvent format with delimiter as ; and quote qualifier of ~. Additionally it adds a new custom format of the input data. 