### PR TITLE
fix table ownership and creation of monitoring tables

### DIFF
--- a/functions/processing.py
+++ b/functions/processing.py
@@ -38,6 +38,8 @@ def generate_table(table_name: str) -> None:
 
         df = read_table(spark_generate, 'undefined_ao_landingzone')
 
+        df = df.distinct()
+
         write_table(spark_generate, df, 'undefined_ao_raw')
 
     elif table_name == 'cut_off_ao_raw':

--- a/functions/signalling_functions.py
+++ b/functions/signalling_functions.py
@@ -360,9 +360,10 @@ def calculate_signalling_issues(spark_session: SparkSession, dataframe: DataFram
 
         signalling_check_df = signalling_check_df.withColumn('valid_count', F.lit(valid_count).cast(IntegerType()))\
                                 .withColumn('check_id',F.lit(check_id))\
-                                .withColumn('check_name',F.lit(description_string))
+                                .withColumn('check_name',F.lit(description_string))\
+                                .withColumn('signalling_id',F.lit(None))
         
-        df = df.union(signalling_check_df).select(['check_id', 'column_name', 'check_name', 'total_count', 'valid_count'])
+        df = df.union(signalling_check_df).select(['signalling_id','check_id', 'column_name', 'check_name', 'total_count', 'valid_count'])
 
     return df
 

--- a/functions/signalling_functions.py
+++ b/functions/signalling_functions.py
@@ -83,7 +83,7 @@ def calculate_filled_values(dataframe: DataFrame) -> DataFrame:
             .withColumn('signalling_id', F.lit(None)) \
             .withColumnRenamed('invalid_count_column', 'column_name')
     col_order = ['signalling_id','check_id', 'column_name', 'check_name', 'total_count', 'valid_count']
-    df = df.select(col_order)
+    df = df.select(col_order).filter(~F.col('column_name').isin(['from_date','to_date','tiltRecordID']))
 
     return df
 


### PR DESCRIPTION
This is the hotfix for the ownership of tables by setting the owner to the tiltDevelopers group. Additionally it adds the correct assignment of signalling ids so there are no more errors on that part. I also excluded the from and to date from the monitoring tables, as it is not relevant to monitor. 