### PR TITLE
Fix monitoring table

### DIFF
--- a/functions/custom_dataframes.py
+++ b/functions/custom_dataframes.py
@@ -209,6 +209,9 @@ class CustomDF(DataReader):
             - The specific checks performed depend on the definitions in the 'signalling_checks_dictionary'.
         """
 
+        # Force to read the table again, to make sure that the table is not empty and we can calculate the signalling issues
+        base_monitoring_df = self.read_source()
+
         signalling_checks = {}
         # Check if there are additional data quality monitoring checks to be executed
         if self._name in signalling_checks_dictionary.keys():
@@ -216,7 +219,7 @@ class CustomDF(DataReader):
 
         # Generate the monitoring values table to be written
         monitoring_values_df = calculate_signalling_issues(
-            self._df, signalling_checks, self._spark_session)
+            base_monitoring_df, signalling_checks, self._spark_session)
         monitoring_values_df = monitoring_values_df.withColumn(
             'table_name', F.lit(self._name))
 
@@ -290,56 +293,56 @@ class CustomDF(DataReader):
         """
         # Define the table name using the environment variable
         table_name = f"{self._env}.monitoring.record_tracing"
-        
+
         # Get the schema for the "record_trace" table
         trace_schema = get_table_definition(self._layer, "record_trace")
-        
+
         # Generate SQL strings to create the schema and set the owner of the schema
         create_schema_string, set_owner_schema_string = create_catalog_schema(
             self._env, trace_schema)
-        
+
         # Generate SQL strings to create the table and set the owner of the table
         create_string = create_catalog_table(
             table_name, trace_schema)
         set_owner_string = create_catalog_table_owner(
             table_name)
-        
+
         # Execute the SQL strings
         self._spark_session.sql(create_schema_string)
         self._spark_session.sql(set_owner_schema_string)
         self._spark_session.sql(create_string)
         self._spark_session.sql(set_owner_string)
-        
+
         # Find the map_column
         map_col = [
             col for col in self._df.columns if col.startswith('map_')][0]
-        
+
         # Filter the DataFrame to only include rows that are newly created. Only for the new rows we want to dump the new record traces.
         dump_df = self._df.where(F.col('to_date') == '2099-12-31')
-        
+
         # Add a new column 'target_table_name' with the name of the table, and rename 'tiltRecordID' to 'target_tiltRecordID'
         dump_df = dump_df.withColumn('target_table_name', F.lit(
             self._name)).withColumnRenamed('tiltRecordID', 'target_tiltRecordID')
-        
+
         # Explode the map column to be able to write the array format to a standard sql table
         dump_df = dump_df.select('*', F.explode(map_col).alias('source_table_name', 'source_tiltRecordID_list')
                                  ).select('*', F.explode(F.col('source_tiltRecordID_list')).alias('source_tiltRecordID'))
-        
+
         # Select only the columns 'source_tiltRecordID', 'source_table_name', 'target_tiltRecordID', and 'target_table_name'
         dump_df = dump_df.select(F.col('source_tiltRecordID'), F.col('source_table_name'), F.col(
             'target_tiltRecordID'), F.col('target_table_name'))
-        
+
         # Read the existing record tracing table into a DataFrame
         df = self._spark_session.read.format(
             'delta').table(table_name)
-        
+
         # Filter the DataFrame to only include rows where for the current table
         df = df.filter(F.col('target_table_name') == self._name)
-        
+
         # Union the two DataFrames and write the result to the table, partitioned by the name of the table
         dump_df.union(df).write.partitionBy('target_table_name').mode(
             'overwrite').format('delta').saveAsTable(table_name)
-        
+
         # Drop the map column from the original DataFrame
         self._df = self._df.drop(F.col(map_col))
 


### PR DESCRIPTION
Hi, 

this is the underlying fix for the empty monitoring table counts. After the write of the table to storage, it is not forced to cache the table meaning that sometimes it does lead to a valid count of 0 in the monitoring values table. I also confirmed that Sohail does not run into his error again, when using this code. 

I have also checked that it eliminates the 0 count rows in the monitoring table when rerunning the monitoring checks.

Cheers,
Sven