### PR TITLE
Fix map column for existing records

### DIFF
--- a/functions/custom_dataframes.py
+++ b/functions/custom_dataframes.py
@@ -351,7 +351,7 @@ class CustomDF(DataReader):
         dump_df = dump_df.drop_duplicates()
 
         # Union the two DataFrames and write the result to the table, partitioned by the name of the table
-        dump_df.union(df).write.partitionBy('target_table_name').mode(
+        dump_df.union(df).distinct().write.partitionBy('target_table_name').mode(
             'overwrite').format('delta').saveAsTable(table_name)
 
         # Drop the map column from the original DataFrame

--- a/functions/dataframe_helpers.py
+++ b/functions/dataframe_helpers.py
@@ -258,9 +258,11 @@ def apply_scd_type_2(new_table: DataFrame, existing_table: DataFrame) -> DataFra
     )
     if identical_records.count() > 0:
         identical_records = combined_df.filter(
-            (F.col("shaValueOld").isNotNull()) & (F.col("shaValueNew").isNotNull())
-        ).join(old_df, on="shaValueOld", how="inner")
-        identical_records = identical_records.select(value_columns + from_to_list)
+            (F.col("shaValueOld").isNotNull()) & (
+                F.col("shaValueNew").isNotNull())
+        ).join(new_data_frame, on="shaValueNew", how="inner")
+        identical_records = identical_records.select(
+            value_columns + from_to_list)
         all_records = all_records.union(identical_records)
 
     # Records that do not exist anymore are taken from the existing set of data


### PR DESCRIPTION
Hi, 

I noticed that when regenerating a table, we do not account for the record tracing column correctly. What happens is that on the generation of a table the old records are chosen for overlapping information between the old and the new table. This means that the record tracing from the incoming table is not identified and subsequently written to the table. 

So in the end instead of choosing the old information that does not include the tracing column, we want to take the new information that does include the tracing column for the overlapping records. 

Cheers,
Sven